### PR TITLE
Making the bgp peer password var sensitive

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -97,7 +97,7 @@ resource "aci_rest_managed" "bgpPeerP" {
     addr             = each.value.ip
     descr            = each.value.description
     ctrl             = join(",", concat(each.value.allow_self_as == true ? ["allow-self-as"] : [], each.value.as_override == true ? ["as-override"] : [], each.value.disable_peer_as_check == true ? ["dis-peer-as-check"] : [], each.value.next_hop_self == true ? ["nh-self"] : [], each.value.send_community == true ? ["send-com"] : [], each.value.send_ext_community == true ? ["send-ext-com"] : []))
-    password         = each.value.password
+    password         = sensitive(each.value.password)
     allowedSelfAsCnt = each.value.allowed_self_as_count
     peerCtrl         = join(",", concat(each.value.bfd == true ? ["bfd"] : [], each.value.disable_connected_check == true ? ["dis-conn-check"] : []))
     ttl              = each.value.ttl


### PR DESCRIPTION
Same approach as with the VMM vCenter password.